### PR TITLE
Allow deterministically pseudorandom output

### DIFF
--- a/gomarkov_test.go
+++ b/gomarkov_test.go
@@ -1,6 +1,7 @@
 package gomarkov
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
 )
@@ -238,5 +239,34 @@ func TestChain_Generate(t *testing.T) {
 				t.Errorf("Chain.Generate() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestChain_GenerateDeterministic(t *testing.T) {
+	chain := NewChain(2)
+	chain.Add(NGram{"i", "like", "bees"})
+	chain.Add(NGram{"i", "like", "cake"})
+	chain.Add(NGram{"i", "like", "pizza"})
+	chain.Add(NGram{"i", "like", "tacos"})
+
+	pairs := map[int64]string{
+		0:    "cake",
+		1:    "bees",
+		10:   "cake",
+		100:  "pizza",
+		1000: "bees",
+	}
+	for seed, expected := range pairs {
+		for i := 0; i < 16; i++ {
+			prng := rand.New(rand.NewSource(seed))
+			got, err := chain.GenerateDeterministic(NGram{"i", "like"}, prng)
+			if err != nil {
+				panic(err) // you wrote a bad test and should feel bad
+			}
+			if got != expected {
+				t.Errorf("Chain.GenerateDeterministic() is not deterministic; seed = %d, got = %q, want %q", seed, got, expected)
+				break
+			}
+		}
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -1,20 +1,32 @@
 package gomarkov
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
-//Pair is a pair of consecutive states in a sequece
+// Pair is a pair of consecutive states in a sequece
 type Pair struct {
 	CurrentState NGram  // n = order of the chain
 	NextState    string // n = 1
 }
 
-//NGram is a array of words
+// NGram is a array of words
 type NGram []string
 
 type sparseArray map[int]int
 
 func (ngram NGram) key() string {
 	return strings.Join(ngram, "_")
+}
+
+func (s sparseArray) orderedKeys() []int {
+	keys := make([]int, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
 }
 
 func (s sparseArray) sum() int {
@@ -40,7 +52,7 @@ func array(value string, count int) []string {
 	return arr
 }
 
-//MakePairs generates n-gram pairs of consecutive states in a sequence
+// MakePairs generates n-gram pairs of consecutive states in a sequence
 func MakePairs(tokens []string, order int) []Pair {
 	var pairs []Pair
 	for i := 0; i < len(tokens)-order; i++ {


### PR DESCRIPTION
I'm using Markov chains for data sanitization where reproducibility is important i.e. if the same English phrase appears in several places in a spreadsheet, I need it to be replaced with a random phrase _but the same random phrase every time_ so that sanitization will not ruin equality relationships between spreadsheet cells.

Using `gomarkov` with provided PRNG sources is just the ticket.